### PR TITLE
Enhance consultation creation and editing functionality

### DIFF
--- a/app/Http/Controllers/Admin/ConsultationController.php
+++ b/app/Http/Controllers/Admin/ConsultationController.php
@@ -30,6 +30,9 @@ class ConsultationController extends Controller
             'time' => 'required|integer|min:1',
         ]);
 
+        // Handle checkbox - if not present, set to false
+        $validated['show_on_consultation_page'] = $request->has('show_on_consultation_page') ? true : false;
+
         Consultation::create($validated);
 
         return redirect()->route('backend.consultations.index')->with('success', 'Consultation created successfully.');

--- a/resources/views/backend/pages/consultations/create.blade.php
+++ b/resources/views/backend/pages/consultations/create.blade.php
@@ -8,7 +8,7 @@
         <div class="border-0 mb-4">
             <div class="card-header pb-3 no-bg bg-transparent d-flex align-items-center px-0 justify-content-between border-bottom">
                 <h3 class="fw-bold mb-0">Create Consultation</h3>
-                <a type="button" href="{{ route('dashboard') }}" class="btn btn-primary btn-set-task">Back</a>
+                <a type="button" href="{{ route('backend.consultations.index') }}" class="btn btn-primary btn-set-task">Back</a>
             </div>
         </div>
     </div>

--- a/resources/views/backend/pages/consultations/edit.blade.php
+++ b/resources/views/backend/pages/consultations/edit.blade.php
@@ -8,7 +8,7 @@
         <div class="border-0 mb-4">
             <div class="card-header pb-3 no-bg bg-transparent d-flex align-items-center px-0 justify-content-between border-bottom">
                 <h3 class="fw-bold mb-0">Edit Consultation</h3>
-                <a type="button" href="{{ route('dashboard') }}" class="btn btn-primary btn-set-task">Back</a>
+                <a type="button" href="{{ route('backend.consultations.index') }}" class="btn btn-primary btn-set-task">Back</a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
- Added logic to handle the 'show_on_consultation_page' checkbox in the ConsultationController, ensuring it defaults to false if not present.
- Updated the 'Back' button links in both the create and edit consultation views to redirect to the consultations index page for better navigation.