### PR TITLE
Update footer links to improve navigation

### DIFF
--- a/resources/views/front/includes/footer.blade.php
+++ b/resources/views/front/includes/footer.blade.php
@@ -43,7 +43,7 @@
                 <a class="footer-link" style="position: relative;" href="https://athleatshop.com/" target="_blank">Shop</a>
                 @endif
                 <div class="dropdown">
-                    <a class="footer-link dropdown-toggle coming-soon-popup" role="button" id="servicesDropdown" data-bs-toggle="dropdown" aria-expanded="false">Services</a>
+                    <a class="footer-link" href="#choose-plan-section">Services</a>
                     {{-- <ul class="dropdown-menu" aria-labelledby="servicesDropdown">
                         <li><a class="dropdown-item" href="{{ route('front.training.nutrition.plan') }}">Training Nutrition Plan</a></li>
                         <li><a class="dropdown-item" href="{{ route('front.competition.plan') }}">Competition plan</a></li>


### PR DESCRIPTION
Replaced the dropdown link for "Services" in the footer with a direct link to the "choose-plan-section" for better user accessibility and streamlined navigation.